### PR TITLE
special external storage (2s2h)

### DIFF
--- a/cmake/dependencies/android.cmake
+++ b/cmake/dependencies/android.cmake
@@ -3,10 +3,13 @@ include(FetchContent)
 #=================== SDL2 ===================
 find_package(SDL2 QUIET)
 if (NOT ${SDL2_FOUND})
+    # if SDL_SHARED_ENABLED_BY_DEFAULT unset, for me libSDL2.so entirely failed to build and link, causing a vague runtime error:
+    # java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.ViewGroup.addView(android.view.View)' on a null object reference
+    set(SDL_SHARED_ENABLED_BY_DEFAULT ON)
     FetchContent_Declare(
         SDL2
         GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
-        GIT_TAG release-2.30.5
+        GIT_TAG release-2.32.0
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(SDL2)
@@ -31,7 +34,14 @@ if (NOT ${tinyxml2_FOUND})
     FetchContent_Declare(
         tinyxml2
         GIT_REPOSITORY https://github.com/leethomason/tinyxml2.git
-        GIT_TAG 10.0.0
+        # last currently good commit of tinyxml2 at time of writing for 32-bit android 5 & 6
+        # see discussion here
+        # https://github.com/leethomason/tinyxml2/pull/945
+        # https://github.com/leethomason/tinyxml2/pull/973
+        # 32-bit bionic libc documentation and test code sample for targeting 32-bit android 5 & 6
+        # is helpful for debugging this and identifying good commits:
+        # https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md
+        GIT_TAG a977397
         OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(tinyxml2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -194,6 +194,10 @@ target_link_libraries(libultraship PUBLIC tinyxml2::tinyxml2)
 find_package(spdlog REQUIRED)
 target_link_libraries(libultraship PUBLIC spdlog::spdlog)
 
+if (CMAKE_SYSTEM_NAME STREQUAL "Android")
+    target_link_libraries(libultraship PRIVATE log)
+endif()
+
 if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
@@ -276,6 +280,7 @@ else()
         $<$<NOT:$<CONFIG:Debug>>:SPDLOG_ACTIVE_LEVEL=1>
         $<$<BOOL:${USE_OPENGLES}>:USE_OPENGLES>
         $<$<BOOL:${GFX_DEBUG_DISASSEMBLER}>:GFX_DEBUG_DISASSEMBLER>
+        "-DANDROID_APPNAME=\"${ANDROID_APPNAME}\""
     )
 endif()
 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -4,6 +4,11 @@
 #include <spdlog/async.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
+#ifdef __ANDROID__
+#include <jni.h>
+#include <SDL2/SDL.h>
+#include "spdlog/sinks/android_sink.h"
+#endif
 #include "install_config.h"
 #include "graphic/Fast3D/debug/GfxDebugger.h"
 #include "graphic/Fast3D/Fast3dWindow.h"
@@ -143,6 +148,11 @@ void Context::InitLogging() {
         fileSink->set_level(spdlog::level::debug);
 #endif
         sinks.push_back(fileSink);
+
+#ifdef __ANDROID__
+        auto logcatSink = std::make_shared<spdlog::sinks::android_sink_mt>(GetName(), ANDROID_APPNAME);
+        sinks.push_back(logcatSink);
+#endif
 
         mLogger = std::make_shared<spdlog::async_logger>(GetName(), sinks.begin(), sinks.end(), spdlog::thread_pool(),
                                                          spdlog::async_overflow_policy::block);
@@ -316,10 +326,7 @@ std::string Context::GetShortName() {
 
 std::string Context::GetAppBundlePath() {
 #if defined(__ANDROID__)
-    const char* externaldir = SDL_AndroidGetExternalStoragePath();
-    if (externaldir != NULL) {
-        return externaldir;
-    }
+    return GetAppDirectoryPath();
 #endif
 
 #ifdef __IOS__
@@ -357,10 +364,19 @@ std::string Context::GetAppBundlePath() {
 
 std::string Context::GetAppDirectoryPath(std::string appName) {
 #if defined(__ANDROID__)
-    const char* externaldir = "/storage/emulated/0/Android/data/com.dishii.mm/files"; //SDL_AndroidGetExternalStoragePath();
-    if (externaldir != NULL) {
-        return externaldir;
-    }
+    JNIEnv* javaEnv = (JNIEnv*)SDL_AndroidGetJNIEnv();
+    jobject javaObject = (jobject)SDL_AndroidGetActivity();
+
+    jclass javaClass = javaEnv->GetObjectClass(javaObject);
+    jmethodID getExternalAssetsPathMethod = javaEnv->GetMethodID(javaClass, "getExternalAssetsPath", "()Ljava/lang/String;");
+    jstring externalAssetsPath_jstr = static_cast<jstring>(javaEnv->CallObjectMethod(javaObject, getExternalAssetsPathMethod));
+
+    const char *externalAssetsPath_cstr = javaEnv->GetStringUTFChars(externalAssetsPath_jstr, nullptr);
+    std::string externalAssetsPath(externalAssetsPath_cstr);
+
+    javaEnv->ReleaseStringUTFChars(externalAssetsPath_jstr, externalAssetsPath_cstr);
+
+    return externalAssetsPath;
 #endif
 
 #ifdef __IOS__


### PR DESCRIPTION
- bump SDL to 2.32.0
- drop tinyxml2 to https://github.com/leethomason/tinyxml2/commit/a9773976845b19e89020c1215781e71116477ef1
- force `SDL_SHARED_ENABLED_BY_DEFAULT`
- enable spdlog logcat backend
- add Special External Storage Permission support