### PR TITLE
[Android] Init & Exit functions (SoH)

### DIFF
--- a/src/port/android/AndroidImpl.cpp
+++ b/src/port/android/AndroidImpl.cpp
@@ -54,6 +54,18 @@ void LUS::Android::adjustGyro(float gyroData[3]){
 #include <SDL_gamecontroller.h>
 #include <jni.h>
 
+void LUS::Android::Init() {
+    // None (add here Android initialization steps)
+}
+
+void LUS::Android::Exit() {
+    SDL_Event quit_event;
+    quit_event.type = SDL_QUIT;
+    SDL_PushEvent(&quit_event);
+    SDL_Quit();
+    exit(0);
+}
+
 bool LUS::Android::IsUsingTouchscreenControls(){
     return isUsingTouchscreenControls;
 }

--- a/src/port/android/AndroidImpl.h
+++ b/src/port/android/AndroidImpl.h
@@ -9,6 +9,8 @@ namespace LUS {
 
 class Android {
   public:
+    static void Init();
+    static void Exit();
     static void ImGuiProcessEvent(bool wantsTextInput);
     static void adjustGyro(float gyroData[3]);
     static bool IsUsingTouchscreenControls();


### PR DESCRIPTION
This PR adds Android Init() and Exit() functions.

- The Init() function is empty, but has been define to match same existing function in WiiU and Switch ports.

- The Exit() function target to close SDL and the Android App in a safe and defined way.

Regards.