### PR TITLE
Fix android back button open enhancement menu

### DIFF
--- a/src/window/gui/Gui.cpp
+++ b/src/window/gui/Gui.cpp
@@ -56,6 +56,9 @@ namespace Ship {
 
 #define TOGGLE_BTN ImGuiKey_F1
 #define TOGGLE_PAD_BTN ImGuiKey_GamepadBack
+#if defined(__ANDROID__)
+#define TOGGLE_BACK_BTN ImGuiKey_AppBack
+#endif
 
 Gui::Gui(std::vector<std::shared_ptr<GuiWindow>> guiWindows) : mNeedsConsoleVariableSave(false) {
     mGameOverlay = std::make_shared<GameOverlay>();
@@ -484,6 +487,42 @@ void Gui::DrawMenu() {
 
     ImGui::DockSpace(dockId, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None | ImGuiDockNodeFlags_NoDockingInCentralNode);
 
+#if defined(__ANDROID__)
+    bool anyMenuKeyPressed = (
+        ImGui::IsKeyPressed(ImGuiKey_Escape, false) ||
+        ImGui::IsKeyPressed(TOGGLE_BACK_BTN, false) ||
+        ImGui::IsKeyPressed(TOGGLE_BTN, false) ||
+        (ImGui::IsKeyPressed(TOGGLE_PAD_BTN, false) && CVarGetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0))
+    );
+
+    if (anyMenuKeyPressed) {
+        // Open Menu if any Menu key is pressed and the Menu is available
+        // If Menu is not available, open Menu Bar if it is available
+        if (GetMenu()) {
+            GetMenu()->ToggleVisibility();
+        }
+        else if (GetMenuBar()) {
+            GetMenuBar()->ToggleVisibility();
+        }
+
+        if (wnd->IsFullscreen()) {
+            Context::GetInstance()->GetWindow()->SetMouseCapture(
+                !(GetMenuOrMenubarVisible() || wnd->ShouldForceCursorVisibility()));
+        }
+
+        if (CVarGetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0) && GetMenuOrMenubarVisible()) {
+            mImGuiIo->ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
+        } else {
+            mImGuiIo->ConfigFlags &= ~ImGuiConfigFlags_NavEnableGamepad;
+        }
+
+        if(GetMenuOrMenubarVisible()) {
+            Ship::Mobile::DisableTouchArea();
+        } else {
+            Ship::Mobile::EnableTouchArea();
+        }
+    }
+#else
     if (ImGui::IsKeyPressed(TOGGLE_BTN, false) || ImGui::IsKeyPressed(ImGuiKey_Escape, false) ||
         (ImGui::IsKeyPressed(TOGGLE_PAD_BTN, false) && CVarGetInteger(CVAR_IMGUI_CONTROLLER_NAV, 0))) {
         if ((ImGui::IsKeyPressed(ImGuiKey_Escape, false) || ImGui::IsKeyPressed(TOGGLE_PAD_BTN, false)) && GetMenu()) {
@@ -501,14 +540,8 @@ void Gui::DrawMenu() {
         } else {
             mImGuiIo->ConfigFlags &= ~ImGuiConfigFlags_NavEnableGamepad;
         }
-#ifdef __ANDROID__
-        if(GetMenuOrMenubarVisible()){
-            Ship::Mobile::DisableTouchArea();
-        }else{
-            Ship::Mobile::EnableTouchArea();
-        }
-#endif
     }
+#endif
 
     // Mac interprets this as cmd+r when io.ConfigMacOSXBehavior is on (on by default)
     if ((ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) &&


### PR DESCRIPTION
Hello,

Android back button was not opening the menu cause:

- Now we are using the default imgui_impl_sdl2.cpp backend (instead of the custom one used in previous version), so the back button [should be handle as ImGuiKey_AppBack](https://github.com/ocornut/imgui/blob/947aa9c9722bd6ff740dd757da609ff41f4d3ba3/backends/imgui_impl_sdl2.cpp#L330) instead of ImGuiKey_F1.

- When ImGuiKey_F1 is received at Gui.cpp, it tries to open the "MenuBar" instead of the "Menu", and seems this MenuBar [is no longer initialized neither used](https://github.com/Waterdish/Shipwright-Android/blob/942be7528486a8c6861b411ed3fedf2971e265c1/soh/soh/SohGui/SohGui.cpp#L109-L119) by SoH at 9.0.2.

This Pull Request fix the handling of the Back button to open the Menu with it.

Best Regards :)